### PR TITLE
Add Portuguese (Portugal/pt-PT) translation for cookie banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Set style in config object `glowCookies.start('en', { style: 3 })`
 Now you can choose between these available languages:
 - Afrikaans (`af`)
 - Brazilian portugese (`pt_BR`)
+- European portugese (`pt_PT`)
 - Bulgarian (`bg`)
 - Catalan (`ca`)
 - Chinese Simple (`zh`)

--- a/src/glowCookies.js
+++ b/src/glowCookies.js
@@ -414,6 +414,14 @@ class LanguagesGC {
         'rejectBtnText': 'Rejeitar',
         'manageText': 'Gerenciar cookies'
       },
+      pt_PT: {
+        'bannerHeading': 'Utilização de cookies',
+        'bannerDescription': 'Utilizamos cookies próprios e de terceiros para personalizar o conteúdo e analisar o tráfego da web.',
+        'bannerLinkText': 'Saiba mais sobre os cookies',
+        'acceptBtnText': 'Aceitar cookies',
+        'rejectBtnText': 'Rejeitar',
+        'manageText': 'Gerir cookies'
+      },
       ru: {
         'bannerHeading': 'Позвольте использовать куки?',
         'bannerDescription': 'Мы используем собственные и сторонние куки для персонализации контента и анализа веб-трафика.',


### PR DESCRIPTION
This pull request adds the Portuguese (Portugal) version of the cookie banner text.